### PR TITLE
Install workflow module when initilizing

### DIFF
--- a/aria_core/processor/blueprint_processor.py
+++ b/aria_core/processor/blueprint_processor.py
@@ -27,6 +27,11 @@ def create_requirements(blueprint_path):
         plugins=parsed_dsl[
             futures.aria_dsl_constants.DEPLOYMENT_PLUGINS_TO_INSTALL
         ]
+    ) | _plugins_to_requirements(
+        blueprint_path=blueprint_path,
+        plugins=parsed_dsl[
+            futures.aria_dsl_constants.WORKFLOW_PLUGINS_TO_INSTALL
+        ]
     )
 
     for node in parsed_dsl['nodes']:


### PR DESCRIPTION
Add module installation for workflows in Aria-core. The workflows are typically installed on Cloudify Manager or hosts, and installation of workflows are handled by Cloudify Manager or agents. In Aria (local mode), the workflows require to be installed locally.